### PR TITLE
Changes heights of card images to be responsive

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -273,9 +273,8 @@ body {
 .comment,
 .delete,
 .star-active {
-  height: auto;
-  max-width: 15%;
-  min-width: 15%;
+  height: 6vh;
+  width: 5em;
 }
 
 /*=== media queries ===*/
@@ -399,11 +398,4 @@ body {
     width: 100%;
   }
 
-  .comment,
-  .delete,
-  .star-active, {
-    height: auto;
-    max-width: 11%;
-    min-width: 5%;
-  }
 }


### PR DESCRIPTION
I changed the height of the .comment, .delete, and .star-archive images so that they would be responsive to the changing window sizes. This means we don't need special sizing in the media queries! 